### PR TITLE
Updating package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular2-quickstart",
   "version": "1.0.0",
   "scripts": {
-    "postinstall": " ./node_modules/.bin/typings install",
+    "postinstall": "typings install",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",


### PR DESCRIPTION
The current version directly ties to the folder structure of a Linux or OSX-based Operating system.  By removing that line and replacing it with a CLI call, windows-based node engines will now be able to work.

Thanks.